### PR TITLE
Support reading and writing SFEN

### DIFF
--- a/lib/shogi.d.ts
+++ b/lib/shogi.d.ts
@@ -27,6 +27,7 @@ export declare class Shogi {
     drop(tox: number, toy: number, kind: string, color?: Color): void;
     undrop(tox: number, toy: number): void;
     toCSAString(): string;
+    toSFENString(moveCount?: number): string;
     getMovesFrom(x: number, y: number): Move[];
     getDropsBy(color: Color): Move[];
     getMovesTo(x: number, y: number, kind: string, color?: Color): Move[];

--- a/lib/shogi.d.ts
+++ b/lib/shogi.d.ts
@@ -90,4 +90,5 @@ export declare class Piece {
     static getMoveDef(kind: string): MoveDefinition;
     static isPromoted(kind: string): boolean;
     static oppositeColor(color: Color): Color;
+    static fromSFENString(sfen: string): Piece;
 }

--- a/lib/shogi.d.ts
+++ b/lib/shogi.d.ts
@@ -21,6 +21,7 @@ export declare class Shogi {
     flagEditMode: boolean;
     constructor(setting?: SettingType);
     initialize(setting?: SettingType): void;
+    initializeFromSFENString(sfen: string): void;
     editMode(flag: boolean): void;
     move(fromx: number, fromy: number, tox: number, toy: number, promote?: boolean): void;
     unmove(fromx: number, fromy: number, tox: number, toy: number, promote?: boolean, capture?: string): void;

--- a/lib/shogi.d.ts
+++ b/lib/shogi.d.ts
@@ -82,6 +82,7 @@ export declare class Piece {
     unpromote(): void;
     inverse(): void;
     toCSAString(): string;
+    toSFENString(): string;
     static promote(kind: string): string;
     static unpromote(kind: string): string;
     static canPromote(kind: string): boolean;

--- a/lib/shogi.js
+++ b/lib/shogi.js
@@ -1,3 +1,4 @@
+"use strict";
 /** @license
  * Shogi.js
  * Copyright (c) 2014 na2hiro (https://github.com/na2hiro)
@@ -537,7 +538,7 @@ var Shogi = (function () {
         }
     };
     return Shogi;
-})();
+}());
 exports.Shogi = Shogi;
 // enum Kind {HI, KY, KE, GI, KI, KA, HI, OU, TO, NY, NK, NG, UM, RY}
 var Piece = (function () {
@@ -561,6 +562,21 @@ var Piece = (function () {
     // CSAによる駒表現の文字列を返す
     Piece.prototype.toCSAString = function () {
         return (this.color == Color.Black ? "+" : "-") + this.kind;
+    };
+    // SFENによる駒表現の文字列を返す
+    Piece.prototype.toSFENString = function () {
+        var sfenPiece = {
+            FU: "P",
+            KY: "L",
+            KE: "N",
+            GI: "S",
+            KI: "G",
+            KA: "B",
+            HI: "R",
+            OU: "K"
+        }[Piece.unpromote(this.kind)];
+        return (Piece.isPromoted(this.kind) ? "+" : "") +
+            (this.color == Color.Black ? sfenPiece : sfenPiece.toLowerCase());
     };
     // 成った時の種類を返す．なければそのまま．
     Piece.promote = function (kind) {
@@ -625,5 +641,5 @@ var Piece = (function () {
         return color == Color.Black ? Color.White : Color.Black;
     };
     return Piece;
-})();
+}());
 exports.Piece = Piece;

--- a/lib/shogi.js
+++ b/lib/shogi.js
@@ -692,6 +692,29 @@ var Piece = (function () {
     Piece.oppositeColor = function (color) {
         return color == Color.Black ? Color.White : Color.Black;
     };
+    // SFENによる文字列表現から駒オブジェクトを作成
+    Piece.fromSFENString = function (sfen) {
+        var promoted = sfen[0] == "+";
+        if (promoted) {
+            sfen = sfen.slice(1);
+        }
+        var color = sfen.match(/[A-Z]/) ? "+" : "-";
+        var kind = {
+            P: "FU",
+            L: "KY",
+            N: "KE",
+            S: "GI",
+            G: "KI",
+            B: "KA",
+            R: "HI",
+            K: "OU"
+        }[sfen.toUpperCase()];
+        var piece = new Piece(color + kind);
+        if (promoted) {
+            piece.promote();
+        }
+        return piece;
+    };
     return Piece;
 }());
 exports.Piece = Piece;

--- a/lib/shogi.js
+++ b/lib/shogi.js
@@ -51,6 +51,58 @@ var Shogi = (function () {
         }
         this.flagEditMode = false;
     };
+    // SFENによる盤面表現の文字列で盤面を初期化する
+    Shogi.prototype.initializeFromSFENString = function (sfen) {
+        this.board = [];
+        for (var i = 0; i < 9; i++) {
+            this.board[i] = [];
+            for (var j = 0; j < 9; j++) {
+                this.board[i][j] = null;
+            }
+        }
+        var segments = sfen.split(' ');
+        var sfenBoard = segments[0];
+        var x = 8;
+        var y = 0;
+        for (var i = 0; i < sfenBoard.length; i++) {
+            var c = sfenBoard[i];
+            var promoted = false;
+            if (c == "+") {
+                i++;
+                c += sfenBoard[i];
+            }
+            if (c.match(/^[1-9]$/)) {
+                x -= Number(c);
+            }
+            else if (c == "/") {
+                y++;
+                x = 8;
+            }
+            else {
+                console.log(x, y, c);
+                this.board[x][y] = Piece.fromSFENString(c);
+                x--;
+            }
+        }
+        this.turn = segments[1] == "b" ? Color.Black : Color.White;
+        this.hands = [[], []];
+        var sfenHands = segments[2];
+        if (sfenHands != "-") {
+            while (sfenHands.length > 0) {
+                var count = 1;
+                var m = sfenHands.match(/^[0-9]+/);
+                if (m) {
+                    count = Number(m[0]);
+                    sfenHands = sfenHands.slice(m[0].length);
+                }
+                for (var i = 0; i < count; i++) {
+                    var piece = Piece.fromSFENString(sfenHands[0]);
+                    this.hands[piece.color].push(piece);
+                }
+                sfenHands = sfenHands.slice(1);
+            }
+        }
+    };
     // 編集モード切り替え
     // * 通常モード：移動時に手番と移動可能かどうかチェックし，移動可能範囲は手番側のみ返す．
     // * 編集モード：移動時に手番や移動可能かはチェックせず，移動可能範囲は両者とも返す．

--- a/lib/shogi.js
+++ b/lib/shogi.js
@@ -79,7 +79,6 @@ var Shogi = (function () {
                 x = 8;
             }
             else {
-                console.log(x, y, c);
                 this.board[x][y] = Piece.fromSFENString(c);
                 x--;
             }

--- a/lib/shogi.js
+++ b/lib/shogi.js
@@ -144,6 +144,58 @@ var Shogi = (function () {
         ret.push(this.turn == Color.Black ? "+" : "-");
         return ret.join("\n");
     };
+    // SFENによる盤面表現の文字列を返す
+    Shogi.prototype.toSFENString = function (moveCount) {
+        if (moveCount === void 0) { moveCount = 1; }
+        var ret = [];
+        var sfenBoard = [];
+        for (var y = 0; y < 9; y++) {
+            var line = "";
+            var empty = 0;
+            for (var x = 8; x >= 0; x--) {
+                var piece = this.board[x][y];
+                if (piece == null) {
+                    empty++;
+                }
+                else {
+                    if (empty > 0) {
+                        line += "" + empty;
+                        empty = 0;
+                    }
+                    line += piece.toSFENString();
+                }
+            }
+            if (empty > 0) {
+                line += "" + empty;
+            }
+            sfenBoard.push(line);
+        }
+        ret.push(sfenBoard.join("/"));
+        ret.push(this.turn == Color.Black ? "b" : "w");
+        if (this.hands[0].length == 0 && this.hands[1].length == 0) {
+            ret.push("-");
+        }
+        else {
+            var sfenHands = "";
+            var kinds = ["R", "B", "G", "S", "N", "L", "P", "r", "b", "g", "s", "n", "l", "p"];
+            var count = {};
+            for (var i = 0; i < 2; i++) {
+                for (var j = 0; j < this.hands[i].length; j++) {
+                    var key = this.hands[i][j].toSFENString();
+                    count[key] = (count[key] || 0) + 1;
+                }
+            }
+            for (var i = 0; i < kinds.length; i++) {
+                var kind = kinds[i];
+                if (count[kind] > 0) {
+                    sfenHands += (count[kind] > 1 ? count[kind] : "") + kind;
+                }
+            }
+            ret.push(sfenHands);
+        }
+        ret.push("" + moveCount);
+        return ret.join(" ");
+    };
     // (x, y)の駒の移動可能な動きをすべて得る
     // 盤外，自分の駒取りは除外．二歩，王手放置などはチェックせず．
     Shogi.prototype.getMovesFrom = function (x, y) {

--- a/out/shogi.js
+++ b/out/shogi.js
@@ -80,7 +80,6 @@ var Shogi = (function () {
                 x = 8;
             }
             else {
-                console.log(x, y, c);
                 this.board[x][y] = Piece.fromSFENString(c);
                 x--;
             }

--- a/out/shogi.js
+++ b/out/shogi.js
@@ -52,6 +52,58 @@ var Shogi = (function () {
         }
         this.flagEditMode = false;
     };
+    // SFENによる盤面表現の文字列で盤面を初期化する
+    Shogi.prototype.initializeFromSFENString = function (sfen) {
+        this.board = [];
+        for (var i = 0; i < 9; i++) {
+            this.board[i] = [];
+            for (var j = 0; j < 9; j++) {
+                this.board[i][j] = null;
+            }
+        }
+        var segments = sfen.split(' ');
+        var sfenBoard = segments[0];
+        var x = 8;
+        var y = 0;
+        for (var i = 0; i < sfenBoard.length; i++) {
+            var c = sfenBoard[i];
+            var promoted = false;
+            if (c == "+") {
+                i++;
+                c += sfenBoard[i];
+            }
+            if (c.match(/^[1-9]$/)) {
+                x -= Number(c);
+            }
+            else if (c == "/") {
+                y++;
+                x = 8;
+            }
+            else {
+                console.log(x, y, c);
+                this.board[x][y] = Piece.fromSFENString(c);
+                x--;
+            }
+        }
+        this.turn = segments[1] == "b" ? Color.Black : Color.White;
+        this.hands = [[], []];
+        var sfenHands = segments[2];
+        if (sfenHands != "-") {
+            while (sfenHands.length > 0) {
+                var count = 1;
+                var m = sfenHands.match(/^[0-9]+/);
+                if (m) {
+                    count = Number(m[0]);
+                    sfenHands = sfenHands.slice(m[0].length);
+                }
+                for (var i = 0; i < count; i++) {
+                    var piece = Piece.fromSFENString(sfenHands[0]);
+                    this.hands[piece.color].push(piece);
+                }
+                sfenHands = sfenHands.slice(1);
+            }
+        }
+    };
     // 編集モード切り替え
     // * 通常モード：移動時に手番と移動可能かどうかチェックし，移動可能範囲は手番側のみ返す．
     // * 編集モード：移動時に手番や移動可能かはチェックせず，移動可能範囲は両者とも返す．
@@ -144,6 +196,58 @@ var Shogi = (function () {
         }
         ret.push(this.turn == Color.Black ? "+" : "-");
         return ret.join("\n");
+    };
+    // SFENによる盤面表現の文字列を返す
+    Shogi.prototype.toSFENString = function (moveCount) {
+        if (moveCount === void 0) { moveCount = 1; }
+        var ret = [];
+        var sfenBoard = [];
+        for (var y = 0; y < 9; y++) {
+            var line = "";
+            var empty = 0;
+            for (var x = 8; x >= 0; x--) {
+                var piece = this.board[x][y];
+                if (piece == null) {
+                    empty++;
+                }
+                else {
+                    if (empty > 0) {
+                        line += "" + empty;
+                        empty = 0;
+                    }
+                    line += piece.toSFENString();
+                }
+            }
+            if (empty > 0) {
+                line += "" + empty;
+            }
+            sfenBoard.push(line);
+        }
+        ret.push(sfenBoard.join("/"));
+        ret.push(this.turn == Color.Black ? "b" : "w");
+        if (this.hands[0].length == 0 && this.hands[1].length == 0) {
+            ret.push("-");
+        }
+        else {
+            var sfenHands = "";
+            var kinds = ["R", "B", "G", "S", "N", "L", "P", "r", "b", "g", "s", "n", "l", "p"];
+            var count = {};
+            for (var i = 0; i < 2; i++) {
+                for (var j = 0; j < this.hands[i].length; j++) {
+                    var key = this.hands[i][j].toSFENString();
+                    count[key] = (count[key] || 0) + 1;
+                }
+            }
+            for (var i = 0; i < kinds.length; i++) {
+                var kind = kinds[i];
+                if (count[kind] > 0) {
+                    sfenHands += (count[kind] > 1 ? count[kind] : "") + kind;
+                }
+            }
+            ret.push(sfenHands);
+        }
+        ret.push("" + moveCount);
+        return ret.join(" ");
     };
     // (x, y)の駒の移動可能な動きをすべて得る
     // 盤外，自分の駒取りは除外．二歩，王手放置などはチェックせず．
@@ -640,6 +744,29 @@ var Piece = (function () {
     };
     Piece.oppositeColor = function (color) {
         return color == Color.Black ? Color.White : Color.Black;
+    };
+    // SFENによる文字列表現から駒オブジェクトを作成
+    Piece.fromSFENString = function (sfen) {
+        var promoted = sfen[0] == "+";
+        if (promoted) {
+            sfen = sfen.slice(1);
+        }
+        var color = sfen.match(/[A-Z]/) ? "+" : "-";
+        var kind = {
+            P: "FU",
+            L: "KY",
+            N: "KE",
+            S: "GI",
+            G: "KI",
+            B: "KA",
+            R: "HI",
+            K: "OU"
+        }[sfen.toUpperCase()];
+        var piece = new Piece(color + kind);
+        if (promoted) {
+            piece.promote();
+        }
+        return piece;
     };
     return Piece;
 }());

--- a/out/shogi.js
+++ b/out/shogi.js
@@ -1,4 +1,5 @@
 (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+"use strict";
 /** @license
  * Shogi.js
  * Copyright (c) 2014 na2hiro (https://github.com/na2hiro)
@@ -538,7 +539,7 @@ var Shogi = (function () {
         }
     };
     return Shogi;
-})();
+}());
 exports.Shogi = Shogi;
 // enum Kind {HI, KY, KE, GI, KI, KA, HI, OU, TO, NY, NK, NG, UM, RY}
 var Piece = (function () {
@@ -562,6 +563,21 @@ var Piece = (function () {
     // CSAによる駒表現の文字列を返す
     Piece.prototype.toCSAString = function () {
         return (this.color == Color.Black ? "+" : "-") + this.kind;
+    };
+    // SFENによる駒表現の文字列を返す
+    Piece.prototype.toSFENString = function () {
+        var sfenPiece = {
+            FU: "P",
+            KY: "L",
+            KE: "N",
+            GI: "S",
+            KI: "G",
+            KA: "B",
+            HI: "R",
+            OU: "K"
+        }[Piece.unpromote(this.kind)];
+        return (Piece.isPromoted(this.kind) ? "+" : "") +
+            (this.color == Color.Black ? sfenPiece : sfenPiece.toLowerCase());
     };
     // 成った時の種類を返す．なければそのまま．
     Piece.promote = function (kind) {
@@ -626,7 +642,7 @@ var Piece = (function () {
         return color == Color.Black ? Color.White : Color.Black;
     };
     return Piece;
-})();
+}());
 exports.Piece = Piece;
 
 },{}]},{},[1]);

--- a/src/shogi.ts
+++ b/src/shogi.ts
@@ -273,7 +273,6 @@ export class Shogi {
 				y++;
 				x = 8;
 			}else{
-				console.log(x, y, c);
 				this.board[x][y] = Piece.fromSFENString(c);
 				x--;
 			}

--- a/src/shogi.ts
+++ b/src/shogi.ts
@@ -546,6 +546,21 @@ export class Piece{
 	toCSAString(): string{
 		return (this.color==Color.Black ? "+" : "-")+this.kind;
 	}
+	// SFENによる駒表現の文字列を返す
+	toSFENString(): string{
+		var sfenPiece = {
+			FU: "P", // Pawn
+			KY: "L", // Lance
+			KE: "N", // kNight
+			GI: "S", // Silver
+			KI: "G", // Gold
+			KA: "B", // Bishop
+			HI: "R", // Rook
+			OU: "K", // King
+		}[Piece.unpromote(this.kind)];
+		return (Piece.isPromoted(this.kind) ? "+" : "") +
+		 (this.color==Color.Black ? sfenPiece : sfenPiece.toLowerCase());
+	}
 	// 成った時の種類を返す．なければそのまま．
 	static promote(kind: string): string{
 		return {

--- a/src/shogi.ts
+++ b/src/shogi.ts
@@ -329,6 +329,55 @@ export class Shogi {
 		ret.push(this.turn==Color.Black ? "+" : "-");
 		return ret.join("\n");
 	}
+	// SFENによる盤面表現の文字列を返す
+	toSFENString(moveCount=1): string{
+		var ret = [];
+		var sfenBoard = [];
+		for(var y=0; y<9; y++){
+			var line = "";
+			var empty = 0;
+			for(var x=8; x>=0; x--){
+				var piece = this.board[x][y];
+				if(piece==null){
+					empty++;
+				}else{
+					if(empty>0){
+						line+=""+empty;
+						empty = 0;
+					}
+					line+=piece.toSFENString();
+				}
+			}
+			if(empty>0){
+				line+=""+empty;
+			}
+			sfenBoard.push(line);
+		}
+		ret.push(sfenBoard.join("/"));
+		ret.push(this.turn==Color.Black ? "b" : "w");
+		if(this.hands[0].length==0 && this.hands[1].length==0){
+			ret.push("-");
+		}else{
+			var sfenHands = "";
+			var kinds = ["R","B","G","S","N","L","P","r","b","g","s","n","l","p"];
+			var count = {};
+			for(var i=0; i<2; i++){
+				for(var j=0; j<this.hands[i].length; j++){
+					var key = this.hands[i][j].toSFENString();
+					count[key] = (count[key] || 0) + 1;
+				}
+			}
+			for(var i=0; i<kinds.length; i++){
+				var kind = kinds[i];
+				if(count[kind]>0){
+					sfenHands += (count[kind]>1 ? count[kind] : "") + kind;
+				}
+			}
+			ret.push(sfenHands);
+		}
+		ret.push("" + moveCount);
+		return ret.join(" ");
+	}
 	// (x, y)の駒の移動可能な動きをすべて得る
 	// 盤外，自分の駒取りは除外．二歩，王手放置などはチェックせず．
 	getMovesFrom(x: number, y: number): Move[]{

--- a/src/shogi.ts
+++ b/src/shogi.ts
@@ -668,4 +668,27 @@ export class Piece{
 	static oppositeColor(color: Color): Color{
 		return color==Color.Black ? Color.White : Color.Black;
 	}
+	// SFENによる文字列表現から駒オブジェクトを作成
+	static fromSFENString(sfen: string): Piece{
+		var promoted = sfen[0]=="+";
+		if (promoted){
+			sfen = sfen.slice(1);
+		}
+		var color = sfen.match(/[A-Z]/) ? "+" : "-";
+		var kind = {
+			P: "FU",
+			L: "KY",
+			N: "KE",
+			S: "GI",
+			G: "KI",
+			B: "KA",
+			R: "HI",
+			K: "OU",
+		}[sfen.toUpperCase()];
+		var piece = new Piece(color + kind);
+		if (promoted){
+			piece.promote();
+		}
+		return piece;
+	}
 }

--- a/src/shogi.ts
+++ b/src/shogi.ts
@@ -247,6 +247,56 @@ export class Shogi {
 		}
 		this.flagEditMode = false;
 	}
+	// SFENによる盤面表現の文字列で盤面を初期化する
+	initializeFromSFENString(sfen: string): void{
+		this.board = [];
+		for(var i=0; i<9; i++){
+			this.board[i]=[];
+			for(var j=0; j<9; j++){
+				this.board[i][j] = null;
+			}
+		}
+		var segments = sfen.split(' ');
+		var sfenBoard = segments[0];
+		var x = 8;
+		var y = 0;
+		for(var i=0; i<sfenBoard.length; i++){
+			var c = sfenBoard[i];
+			var promoted = false;
+			if(c=="+"){
+				i++;
+				c += sfenBoard[i];
+			}
+			if(c.match(/^[1-9]$/)){
+				x -= Number(c);
+			}else if(c=="/"){
+				y++;
+				x = 8;
+			}else{
+				console.log(x, y, c);
+				this.board[x][y] = Piece.fromSFENString(c);
+				x--;
+			}
+		}
+		this.turn = segments[1]=="b" ? Color.Black : Color.White;
+		this.hands = [[], []];
+		var sfenHands = segments[2];
+		if (sfenHands!="-"){
+			while(sfenHands.length>0){
+				var count = 1;
+				var m = sfenHands.match(/^[0-9]+/);
+				if(m){
+					count = Number(m[0]);
+					sfenHands = sfenHands.slice(m[0].length);
+				}
+				for(var i=0; i<count; i++){
+					var piece = Piece.fromSFENString(sfenHands[0]);
+					this.hands[piece.color].push(piece);
+				}
+				sfenHands = sfenHands.slice(1);
+			}
+		}
+	}
 	// 編集モード切り替え
 	// * 通常モード：移動時に手番と移動可能かどうかチェックし，移動可能範囲は手番側のみ返す．
 	// * 編集モード：移動時に手番や移動可能かはチェックせず，移動可能範囲は両者とも返す．

--- a/test/pieceTest.js
+++ b/test/pieceTest.js
@@ -51,6 +51,14 @@ describe("class Piece", function(){
 			assert.equal(gi.toCSAString(), "+GI");
 		});
 	});
+	describe("toSFENString", function(){
+		it("normal", function(){
+			assert.equal(new Piece("+GI").toSFENString(), "S");
+			assert.equal(new Piece("-GI").toSFENString(), "s");
+			assert.equal(new Piece("+TO").toSFENString(), "+P");
+			assert.equal(new Piece("-TO").toSFENString(), "+p");
+		})
+	})
 	describe("static promote", function(){
 		it("normal", function(){
 			assert.equal(Piece.promote("KA"), "UM");

--- a/test/pieceTest.js
+++ b/test/pieceTest.js
@@ -80,4 +80,12 @@ describe("class Piece", function(){
 			assert.equal(Piece.canPromote("KI"), false);
 		});
 	});
+	describe("static fromSFENString", function(){
+		it("normal", function(){
+			assert.equal(Piece.fromSFENString("S").toCSAString(), "+GI");
+			assert.equal(Piece.fromSFENString("s").toCSAString(), "-GI");
+			assert.equal(Piece.fromSFENString("+P").toCSAString(), "+TO");
+			assert.equal(Piece.fromSFENString("+p").toCSAString(), "-TO");
+		});
+	})
 });

--- a/test/shogiTest.js
+++ b/test/shogiTest.js
@@ -126,6 +126,40 @@ describe("class Shogi", function(){
 				"-"].join("\n"));
 		});
 	});
+	describe("initializeFromSFENString", function(){
+		it("example 1", function(){
+			shogi.initializeFromSFENString("lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1");
+			assert.equal(shogi.toCSAString(), [
+				"P1-KY-KE-GI-KI-OU-KI-GI-KE-KY",
+				"P2 * -HI *  *  *  *  * -KA * ",
+				"P3-FU-FU-FU-FU-FU-FU-FU-FU-FU",
+				"P4 *  *  *  *  *  *  *  *  * ",
+				"P5 *  *  *  *  *  *  *  *  * ",
+				"P6 *  *  *  *  *  *  *  *  * ",
+				"P7+FU+FU+FU+FU+FU+FU+FU+FU+FU",
+				"P8 * +KA *  *  *  *  * +HI * ",
+				"P9+KY+KE+GI+KI+OU+KI+GI+KE+KY",
+				"P+",
+				"P-",
+				"+"].join("\n"));
+		});
+		it("example 2", function(){
+		shogi.initializeFromSFENString("8l/1l+R2P3/p2pBG1pp/kps1p4/Nn1P2G2/P1P1P2PP/1PS6/1KSG3+r1/LN2+p3L w Sbgn3p 124");
+			assert.equal(shogi.toCSAString(), [
+				"P1 *  *  *  *  *  *  *  * -KY",
+				"P2 * -KY+RY *  * +FU *  *  * ",
+				"P3-FU *  * -FU+KA+KI * -FU-FU",
+				"P4-OU-FU-GI * -FU *  *  *  * ",
+				"P5+KE-KE * +FU *  * +KI *  * ",
+				"P6+FU * +FU * +FU *  * +FU+FU",
+				"P7 * +FU+GI *  *  *  *  *  * ",
+				"P8 * +OU+GI+KI *  *  * -RY * ",
+				"P9+KY+KE *  * -TO *  *  * +KY",
+				"P+00GI",
+				"P-00KA00KI00KE00FU00FU00FU",
+				"-"].join("\n"));
+		});
+	})
 	describe("editMode", function(){
 		it("example 1", function(){
 			shogi.move(7, 7, 7, 6);

--- a/test/shogiTest.js
+++ b/test/shogiTest.js
@@ -391,6 +391,37 @@ describe("class Shogi", function(){
 	describe("toCSAString", function(){
 
 	});
+	describe("toSFENString", function(){
+		it("normal", function(){
+			assert.equal(shogi.toSFENString(),
+				"lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1");
+		});
+		it("color", function(){
+			shogi.initialize({preset:"KY"});
+			assert.equal(shogi.toSFENString(),
+				"lnsgkgsn1/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL w - 1");
+		});
+		it("hands", function(){
+			shogi.move(7, 7, 7, 6);
+			shogi.move(3, 3, 3, 4);
+			shogi.move(8, 8, 2, 2, true);
+			shogi.move(3, 1, 2, 2);
+			assert.equal(shogi.toSFENString(5),
+				"lnsgkg1nl/1r5s1/pppppp1pp/6p2/9/2P6/PP1PPPPPP/7R1/LNSGKGSNL b Bb 5");
+			shogi.move(7, 6, 7, 5);
+			shogi.move(7, 3, 7, 4);
+			shogi.move(7, 5, 7, 4);
+			shogi.move(8, 1, 7, 3);
+			shogi.move(7, 4, 7, 3, true);
+			shogi.move(8, 2, 7, 2);
+			shogi.move(7, 3, 8, 3);
+			assert.equal(shogi.toSFENString(12),
+				"l1sgkg1nl/2r4s1/p+P1ppp1pp/6p2/9/9/PP1PPPPPP/7R1/LNSGKGSNL w BN2Pb 12");
+			shogi.move(7, 2, 7, 9, true);
+			assert.equal(shogi.toSFENString(13),
+				"l1sgkg1nl/7s1/p+P1ppp1pp/6p2/9/9/PP1PPPPPP/7R1/LN+rGKGSNL b BN2Pbs 13");
+		});
+	});
 	describe("getMovesFrom", function(){
 		it("just", function () {
 			assert.deepEqual(shogi.getMovesFrom(7, 7), [{from:{x:7,y:7},to:{x:7,y:6}}]);


### PR DESCRIPTION
Fix #7

以下のメソッドを実装し、SFEN (Shogi Forsyth-Edwards Notation) を読み書きできるようにしました。

* `Shogi.initializeFromSFENString(sfen: string): void`: SFENの読み込み
* `Shogi.toSFENString(moveCount=1): string`: SFENの書き出し
* `static Piece.fromSFENString(sfen: string): Piece`: 駒単体のSFENの読み込み
* `Piece.toSFENString(): string`: 駒単体のSFENの書き出し

## 考慮点

以下の点はどうするのがいいか判断がつかず、モヤモヤしているところです。何かご指摘などあればお願いします。

* SFENの読み込みを行うinitializeFromSFENStringはインスタンスメソッドとして実装しましたが、Pieceと同様にstaticメソッドとしてもいいかもしれません。一旦SettingTypeに変換するより内部のboardなどを直接書き換えたほうがシンプルそうだったのが、インスタンスメソッドとして実装した理由です。
* SFENの書き出しの際、`Shogi.toSFENString()`の引数`moveCount`でSFENの4番目のフィールド（手数）を指定できるようにしました。省略時のデフォルトは`1`です。
* SFENの読み込みの際は、4番目のフィールド（手数）は単に無視しました。
* そもそもSFENの読み書きはShogiやPieceとは別のヘルパー関数としてもいいかもしれません。

## 参考

実装にあたっては、以下のページを参考にしました。

* 将棋所：USIプロトコルとは<br>http://www.geocities.jp/shogidokoro/usi.html
* 将棋の海外伝播などについてのブログ: 3. Forsyth-Edwards notation for shogi　の日本語訳<br>http://shogi.typepad.jp/brainstorm/2007/01/post_11a0.html
* sfen文字列は本来は一意に定まる件 | やねうら王 公式サイト<br>http://yaneuraou.yaneu.com/2016/07/15/sfen%E6%96%87%E5%AD%97%E5%88%97%E3%81%AF%E6%9C%AC%E6%9D%A5%E3%81%AF%E4%B8%80%E6%84%8F%E3%81%AB%E5%AE%9A%E3%81%BE%E3%82%8B%E4%BB%B6/